### PR TITLE
Lint Fix: Adding missing comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 INSTALL_REQUIRES = [
     "gdown",
-    "Pillow<=8.2.0"
+    "Pillow<=8.2.0",
     "opencv-python>=4.1.2.30",
     "torch==1.8.1",
     "torchvision==0.9.1",


### PR DESCRIPTION
Issue: Invalid Metadata
```Error
  Requested stamp-processing==0.1.dev1 from https://files.pythonhosted.org/packages/a8/af/c3ec3611463997b092bcde2e7a73aaa1d745d4a31bb71c1bd86a907525b5/stamp_processing-0.1.dev1-py3-none-any.whl (from -r requirements.in (line 37)) has invalid metadata: Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
      Pillow (<=8.2.0opencv-python>=4.1.2.30)
```